### PR TITLE
Laravel9 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build
 bin
 logs
 vendor
+.idea
 
 ########################
 # General ignore rules #

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "forlabs/lightsaml": "^2.0.0"
+        "litesaml/lightsaml": "^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This probably destroys some of your backwards compatibility...but L9 requires symfony/http-foundation ^6.0. 
forlabs/lightsaml required symfony/http-foundation ~5.0 
forlabs/lightsaml is forked from lightSAML/lightSAML...is 18 commits behind and looks to be abandoned.
lightSAML/lightSAML is no longer being actively developed and recommends using litesaml/lightsaml

looking at the changes that were made in the forlabs fork, my untrained eyes don't see anything that would cause problems with the above dependancy switch...but I'm not sure best how to test the functonality?